### PR TITLE
fix(annotation-engine): glitch on annotation drag

### DIFF
--- a/src/annotation-engine/use-annotation-engine.ts
+++ b/src/annotation-engine/use-annotation-engine.ts
@@ -150,29 +150,37 @@ const useAnnotationEngine = ({
 
             drawScene();
             if (dragStart) {
-                if (startCoordinates && endCoordinates) {
+                if (annotationPointDraggedIndexRef.current === undefined) {
+                    if (startCoordinates && endCoordinates) {
+                        drawLine(
+                            renderingContextRef.current as CanvasRenderingContext2D,
+                            startCoordinates,
+                            endCoordinates,
+                        );
+                        drawPoint(renderingContextRef.current as CanvasRenderingContext2D, endCoordinates);
+                        if (onAnnotationDragged) {
+                            onAnnotationDragged([startCoordinates, endCoordinates]);
+                        }
+                    } else {
+                        drawPoint(
+                            renderingContextRef.current as CanvasRenderingContext2D,
+                            startCoordinates || endCoordinates,
+                        );
+                        if (onAnnotationDragged) {
+                            onAnnotationDragged([startCoordinates || endCoordinates]);
+                        }
+                    }
+                } else {
+                    startCoordinates = {
+                        x: annotationPointsRef.current[annotationPointDraggedIndexRef.current].x,
+                        y: annotationPointsRef.current[annotationPointDraggedIndexRef.current].y,
+                    };
+                    annotationPointsRef.current[annotationPointDraggedIndexRef.current] = draggedCoordinates;
                     drawLine(renderingContextRef.current as CanvasRenderingContext2D, startCoordinates, endCoordinates);
                     drawPoint(renderingContextRef.current as CanvasRenderingContext2D, endCoordinates);
                     if (onAnnotationDragged) {
-                        onAnnotationDragged([startCoordinates, endCoordinates]);
+                        onAnnotationDragged(annotationPointsRef.current);
                     }
-                } else {
-                    drawPoint(renderingContextRef.current as CanvasRenderingContext2D, endCoordinates);
-                    if (onAnnotationDragged) {
-                        onAnnotationDragged([endCoordinates]);
-                    }
-                }
-            }
-            if (annotationPointDraggedIndexRef.current !== undefined) {
-                startCoordinates = {
-                    x: annotationPointsRef.current[annotationPointDraggedIndexRef.current].x,
-                    y: annotationPointsRef.current[annotationPointDraggedIndexRef.current].y,
-                };
-                annotationPointsRef.current[annotationPointDraggedIndexRef.current] = draggedCoordinates;
-                drawLine(renderingContextRef.current as CanvasRenderingContext2D, startCoordinates, endCoordinates);
-                drawPoint(renderingContextRef.current as CanvasRenderingContext2D, endCoordinates);
-                if (onAnnotationDragged) {
-                    onAnnotationDragged(annotationPointsRef.current);
                 }
             }
         };


### PR DESCRIPTION
Lors du drag and drop, il y a trois conditions qui sont prises en compte pendant qu'on drag:

**Pendant la création d'une annotation:**
- (1) Soit on drag le premier point de notre annotation
- (2) Soit on drag le second point

**Pendant l'update d'une annotation:**
- (3) Quand on drag le point que l'on veut changer de position.

Le bug c'était que pendant l'update, les conditions (2) et (3) étaient appelées. Et donc on renvoyait au parent deux jeux de données au lieu d'un seul.