### PR TITLE
feat/click-on-label

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "rollup": "2.51.2",
     "rollup-plugin-typescript2": "0.30.0",
     "tslib": "2.3.0",
-    "typescript": "4.3.2"
+    "typescript": "4.2.2"
   },
   "dependencies": {
     "react": "17.0.2",

--- a/src/annotation-engine/models.ts
+++ b/src/annotation-engine/models.ts
@@ -10,7 +10,7 @@ export type Annotation = {
     name: string;
     type: ShapeType;
     coordinates: Coordinates[];
-    label: {
+    label?: {
         name: string,
         path: Path2D,
     };

--- a/src/annotation-engine/models.ts
+++ b/src/annotation-engine/models.ts
@@ -1,4 +1,4 @@
-export type ShapeType = 'POINT' | 'LINE' | 'POLYGON' | 'POLYLINE';
+export type ShapeType = 'INACTIVE' |'POINT' | 'LINE' | 'POLYGON' | 'POLYLINE';
 
 export type Coordinates = {
     x: number;

--- a/src/annotation-engine/models.ts
+++ b/src/annotation-engine/models.ts
@@ -10,4 +10,8 @@ export type Annotation = {
     name: string;
     type: ShapeType;
     coordinates: Coordinates[];
+    label: {
+        name: string,
+        path: Path2D,
+    };
 };

--- a/src/annotation-engine/models.ts
+++ b/src/annotation-engine/models.ts
@@ -1,3 +1,5 @@
+export type ShapeType = 'POINT' | 'LINE' | 'POLYGON' | 'POLYLINE';
+
 export type Coordinates = {
     x: number;
     y: number;
@@ -6,5 +8,6 @@ export type Coordinates = {
 export type Annotation = {
     id: string;
     name: string;
+    type: ShapeType;
     coordinates: Coordinates[];
 };

--- a/src/annotation-engine/stories.tsx
+++ b/src/annotation-engine/stories.tsx
@@ -1,9 +1,10 @@
+// eslint-disable-next-line max-classes-per-file
 import { Story, Meta } from '@storybook/react';
-import React, { useState, useRef, RefObject } from 'react';
+import React, { useEffect, useState, useRef, RefObject } from 'react';
 import styled from 'styled-components';
 import Button from '../button';
-import { Annotation, Coordinates } from './models';
-import { Events, Handles, Operations, PointId } from './use-annotation-engine';
+import { Annotation, Coordinates, ShapeType } from './models';
+import { Events, Handles, MouseDownEvent, MouseDownOnExistingPointEvent, Operations, PointId, PushKeyEvent, ReleaseKeyEvent } from './use-annotation-engine';
 import AnnotationEngine, { AnnotationEngineProps } from '.';
 
 export default {
@@ -48,15 +49,49 @@ const Label = styled.label`
     color: white;
 `;
 
-const RoadcareBehaviorTemplate: Story<StyledProps> = ({ width, height, ...args }) => {
+type SaveAnnotationFunction = (geometry: Array<Coordinates>, type: ShapeType) => void;
+
+const useSaveAnnotation = () => {
     const [annotations, setAnnotations] = useState<Annotation[]>([]);
     const [annotationToEdit, setAnnotationToEdit] = useState<Annotation | undefined>(undefined);
-    const refAE = useRef<Handles>(null);
-    const [numberOfPoints, setNumberOfPoints] = useState(2);
+
+    const saveAnnotation = (geometry: Array<Coordinates>, type: ShapeType) => {
+        setAnnotations(annotations.map((annotation) => {
+            if (annotation.id === annotationToEdit?.id) {
+                return { ...annotationToEdit, coordinates: geometry, type };
+            }
+
+            return annotation;
+        }));
+        setAnnotationToEdit(undefined);
+        if (!annotationToEdit) {
+            const id = `${annotations.length ? Number(annotations[annotations.length - 1].id) + 1 : 1}`;
+            setAnnotations([...annotations, { id, name: `Mesure ${id}`, coordinates: geometry, type }]);
+        }
+    };
+
+    return {
+        annotations,
+        annotationToEdit, setAnnotationToEdit,
+        saveAnnotation,
+    }
+}
+
+/**
+ * Manages all the necessary states for the Annotation Engine
+ * FIXME: This is not a real state machine, but it manages all the states mecanism from Annotation Engine
+ * In Roadcare, it will make the RoadViewer component lighter!
+ */
+const useEngineStateMachine = (availableShapeTypes: Array<ShapeType>, annotationToEdit: Annotation | undefined, setAnnotationToEdit: React.Dispatch<React.SetStateAction<Annotation | undefined>>, saveAnnotation: SaveAnnotationFunction, refAE: RefObject<Handles>) => {
+    const [numberOfPoints, setNumberOfPoints] = useState(0);
+    const [shapeType, setShapeType] = useState(availableShapeTypes[0]);
+    const [wasOnFirstPoint, setWasOnFirstPoint] = useState(false);
 
     const isModeEdition = () => annotationToEdit !== undefined;
     const isModeCreation = () => !isModeEdition() && numberOfPoints > 0;
     const isModeInactif = () => !isModeCreation() && !isModeEdition();
+    // key codes map for shape validation (polygon and polylines)
+    const shapeFinishedOnKeyCodes = ['Space'];
 
     const initState = () => ({
         dragPoint: undefined,
@@ -66,21 +101,82 @@ const RoadcareBehaviorTemplate: Story<StyledProps> = ({ width, height, ...args }
         dragPoint: PointId | undefined,
         tempPoint: PointId | undefined,
     }>(initState());
-    const saveAnnotation = (geometry: Array<Coordinates>) => {
-        setAnnotations(annotations.map((annotation) => {
-            if (annotation.id === annotationToEdit?.id) {
-                return { ...annotationToEdit, coordinates: geometry };
-            }
 
-            return annotation;
-        }));
+    const cancelCreationAndEdition = () => {
+        state.current = initState();
+        // Cancel edition
         setAnnotationToEdit(undefined);
-        if (!annotationToEdit) {
-            const id = `${annotations.length ? Number(annotations[annotations.length - 1].id) + 1 : 1}`;
-            setAnnotations([...annotations, { id, name: `Mesure ${id}`, coordinates: geometry }]);
-        }
+        // Cancel creation
+        refAE.current?.cancelCreation();
     };
-    const isGeometryComplete = (length: number) => length >= numberOfPoints + (state.current.tempPoint !== undefined ? 1 : 0);
+
+    /**
+     * Set limit of points for the shape when we change the Annotation Engine shape type
+     */
+    useEffect(() => {
+        switch (shapeType) {
+            case 'POINT':
+            default:
+                setNumberOfPoints(1);
+                break;
+            case 'LINE':
+                setNumberOfPoints(2);
+                break;
+        }
+    }, [shapeType]);
+
+    /**
+     * Set Annotation Engine current shapeType when we edit another annotation
+     */
+    useEffect(() => {
+        if (annotationToEdit?.type) {
+            setShapeType(annotationToEdit.type);
+        }
+    }, [annotationToEdit]);
+
+    const isGeometryComplete = (length: number) => {
+        switch (shapeType) {
+            case 'POINT':
+            case 'LINE':
+            default:
+                return length >= numberOfPoints + (state.current.tempPoint !== undefined ? 1 : 0);
+            case 'POLYGON':
+            case 'POLYLINE':
+                return false;
+        }
+    }
+
+    /**
+     * Dedicated to line, polygon and polylines shapes, return true if shape can be manualy complete
+     */
+    const isGeometryReadyToBeManualyComplete = (length: number) => {
+        switch (shapeType) {
+            case 'LINE':
+                return isModeEdition();
+            case 'POLYGON':
+                return length - (state.current.tempPoint !== undefined ? 1 : 0) >= 3;
+            case 'POLYLINE':
+                return length - (state.current.tempPoint !== undefined ? 1 : 0) >= 2;
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Dedicated to polygon shapes, return true if:
+     * - shape is ready to be manualy finished
+     * - mouse is moving on the first point of the shape
+     */
+    const isPolygonReadyToBeManualyCompleteByClickOnFirstPoint = (currentGeometry: Array<Coordinates>, pointIds: Array<PointId>) => {
+        const { length } = currentGeometry;
+        switch (shapeType) {
+            case 'POLYGON':
+                return isGeometryReadyToBeManualyComplete(length) && pointIds.some((id) => id === 0);
+            default:
+                return false;
+        }
+    }
+
     const createNewPoint = (at: Coordinates, currentGeometry: Coordinates[], operations: Operations) => {
         if (state.current.tempPoint === undefined) {
             // First point
@@ -94,11 +190,13 @@ const RoadcareBehaviorTemplate: Story<StyledProps> = ({ width, height, ...args }
             state.current.tempPoint = undefined;
         }
     };
+
     const shapeFinished = (currentGeometry: Coordinates[], operations: Operations) => {
         operations.finishCurrentLine();
         state.current = initState();
-        saveAnnotation(currentGeometry);
+        saveAnnotation(currentGeometry, shapeType);
     };
+
     const lastValidatedPoint = (currentGeometry: Coordinates[]): PointId => {
         if (state.current.tempPoint === currentGeometry.length - 1) {
             return currentGeometry.length - 2;
@@ -106,19 +204,62 @@ const RoadcareBehaviorTemplate: Story<StyledProps> = ({ width, height, ...args }
 
         return currentGeometry.length - 1;
     };
+
     const stillOnPreviousPoint = (onPoints: Array<PointId>, currentGeometry: Array<Coordinates>) => onPoints.includes(lastValidatedPoint(currentGeometry));
 
-    const onEvent = (event: Events, operations: Operations) => {
+    const pushKeyEvent = (event: PushKeyEvent) => {
+        if (event.event.code === 'Space') {
+            // avoid page scrolldown on space key up
+            event.event.preventDefault();
+        }
+    }
+
+    const releaseKeyEvent = (event: ReleaseKeyEvent, operations: Operations) => {
+        if (shapeFinishedOnKeyCodes.includes(event.event.code) && isGeometryReadyToBeManualyComplete(event.currentGeometry.length)) {
+            if (isModeCreation()) {
+                event.currentGeometry.pop();
+            }
+            shapeFinished(event.currentGeometry, operations);
+        }
+    }
+
+    const mouseDownEvent = (event: MouseDownEvent | MouseDownOnExistingPointEvent, operations: Operations) => {
+        createNewPoint(event.at, event.currentGeometry, operations);
+    }
+
+    const handleEvent = (event: Events, operations: Operations): void => {
         if (isModeInactif()) {
             return;
         }
         if (isModeCreation()) {
             switch (event.type) {
+                case 'mouse_move_on_existing_point_event':
+                    if (isPolygonReadyToBeManualyCompleteByClickOnFirstPoint(event.currentGeometry, event.pointIds)) {
+                        setWasOnFirstPoint(true);
+                        operations.highlightExistingPoint(event.at);
+                    }
+                    break;
+                case 'push_key_event':
+                    pushKeyEvent(event);
+                    break;
+                case 'release_key_event':
+                    releaseKeyEvent(event, operations);
+                    break;
                 case 'mouse_down_event':
                 case 'mouse_down_on_existing_point_event':
-                    createNewPoint(event.at, event.currentGeometry, operations);
+                    if (event.type === 'mouse_down_on_existing_point_event'
+                        && isPolygonReadyToBeManualyCompleteByClickOnFirstPoint(event.currentGeometry, event.pointIds)) {
+                        event.currentGeometry.pop();
+                        shapeFinished(event.currentGeometry, operations);
+                        break;
+                    }
+                    mouseDownEvent(event, operations);
                     break;
                 case 'mouse_move_event':
+                    if (wasOnFirstPoint !== false && !isPolygonReadyToBeManualyCompleteByClickOnFirstPoint(event.currentGeometry, [])) {
+                        setWasOnFirstPoint(false);
+                        operations.removeHighlightPoint();
+                    }
                     if (state.current.tempPoint !== undefined) {
                         // move point under cursor
                         operations.movePoint(state.current.tempPoint, event.to);
@@ -133,7 +274,6 @@ const RoadcareBehaviorTemplate: Story<StyledProps> = ({ width, height, ...args }
                     }
                     break;
                 case 'mouse_up_event':
-                    createNewPoint(event.at, event.currentGeometry, operations);
                     if (isGeometryComplete(event.currentGeometry.length)) {
                         shapeFinished(event.currentGeometry, operations);
                     }
@@ -144,8 +284,11 @@ const RoadcareBehaviorTemplate: Story<StyledProps> = ({ width, height, ...args }
         }
         if (isModeEdition()) {
             switch (event.type) {
-                case 'mouse_down_event':
-                    saveAnnotation(event.currentGeometry);
+                case 'push_key_event':
+                    pushKeyEvent(event);
+                    break;
+                case 'release_key_event':
+                    releaseKeyEvent(event, operations);
                     break;
                 case 'mouse_down_on_existing_point_event':
                     [state.current.dragPoint] = event.pointIds;
@@ -157,20 +300,39 @@ const RoadcareBehaviorTemplate: Story<StyledProps> = ({ width, height, ...args }
                     break;
                 case 'mouse_up_on_existing_point_event':
                 case 'mouse_up_event':
+                    if (shapeType === 'POINT') {
+                        saveAnnotation(event.currentGeometry, shapeType);
+                    }
                     state.current.dragPoint = undefined;
                     break;
                 default:
                     // nothing to do
             }
         }
-    };
-    const cancelCreationAndEdition = () => {
-        state.current = initState();
-        // Cancel edition
-        setAnnotationToEdit(undefined);
-        // Cancel creation
-        refAE.current?.cancelCreation();
-    };
+    }
+
+    return {
+        handleEvent,
+        shapeType, setShapeType,
+        cancelCreationAndEdition,
+    }
+}
+
+const RoadcareBehaviorTemplate: Story<StyledProps> = ({ width, height, ...args }) => {
+    const availableShapeTypes: Array<ShapeType> = ['POINT', 'LINE', 'POLYGON', 'POLYLINE'];
+    const refAE = useRef<Handles>(null);
+
+    const {
+        annotations,
+        annotationToEdit, setAnnotationToEdit,
+        saveAnnotation,
+    } = useSaveAnnotation();
+
+    const {
+        handleEvent,
+        shapeType, setShapeType,
+        cancelCreationAndEdition,
+    } = useEngineStateMachine(availableShapeTypes, annotationToEdit, setAnnotationToEdit, saveAnnotation, refAE);
 
     return (
         <AnnotationsContainer>
@@ -181,11 +343,15 @@ const RoadcareBehaviorTemplate: Story<StyledProps> = ({ width, height, ...args }
                 ref={refAE}
                 annotationToEdit={annotationToEdit}
                 annotations={annotations}
-                onEvent={onEvent}
+                onEvent={handleEvent}
             />
             <ActionContainer>
-                <Label>Nombre de points</Label>
-                <input onChange={(event) => setNumberOfPoints(parseInt(event.target.value, 10))} type="number" value={numberOfPoints}/>
+                <Label>Type de forme</Label>
+                <select onChange={(event) => setShapeType(event.target.value as ShapeType)} value={shapeType}>
+                    {
+                        availableShapeTypes.map((sType) => (<option key={sType} value={sType}>{sType}</option>))
+                    }
+                </select>
                 <Button label="Cancel edition" onClick={cancelCreationAndEdition} type="button" />
             </ActionContainer>
             <div style={{ color: 'white' }}>

--- a/src/annotation-engine/stories.tsx
+++ b/src/annotation-engine/stories.tsx
@@ -240,9 +240,9 @@ const useEngineStateMachine = (availableShapeTypes: Array<ShapeType>, annotation
                     console.info(event.pointIds)
                     console.info('clic existing point')
                     break;
-                case 'mouse_move_on_label_area_event':
-                    console.info('move !')
-                    
+                case 'mouse_down_on_annotation_label_event':
+                    console.info('clicked annotation !', event.clickedAnnotation)
+                    setAnnotationToEdit(event.clickedAnnotation);
                     break;
                 default:
                     break;

--- a/src/annotation-engine/stories.tsx
+++ b/src/annotation-engine/stories.tsx
@@ -122,6 +122,9 @@ const useEngineStateMachine = (availableShapeTypes: Array<ShapeType>, annotation
             case 'LINE':
                 setNumberOfPoints(2);
                 break;
+            case 'INACTIVE':
+                setNumberOfPoints(0);
+                break;
         }
     }, [shapeType]);
 
@@ -229,6 +232,17 @@ const useEngineStateMachine = (availableShapeTypes: Array<ShapeType>, annotation
 
     const handleEvent = (event: Events, operations: Operations): void => {
         if (isModeInactif()) {
+            switch (event.type) {
+                case 'mouse_down_event':
+                    break;
+                    case 'mouse_down_on_existing_point_event':
+                    console.info(event.pointIds)
+                    console.info('clic existing point')
+                    break;
+                default:
+                    break;
+            }
+
             return;
         }
         if (isModeCreation()) {
@@ -319,7 +333,7 @@ const useEngineStateMachine = (availableShapeTypes: Array<ShapeType>, annotation
 }
 
 const RoadcareBehaviorTemplate: Story<StyledProps> = ({ width, height, ...args }) => {
-    const availableShapeTypes: Array<ShapeType> = ['POINT', 'LINE', 'POLYGON', 'POLYLINE'];
+    const availableShapeTypes: Array<ShapeType> = ['INACTIVE', 'POINT', 'LINE', 'POLYGON', 'POLYLINE'];
     const refAE = useRef<Handles>(null);
 
     const {

--- a/src/annotation-engine/stories.tsx
+++ b/src/annotation-engine/stories.tsx
@@ -232,12 +232,17 @@ const useEngineStateMachine = (availableShapeTypes: Array<ShapeType>, annotation
 
     const handleEvent = (event: Events, operations: Operations): void => {
         if (isModeInactif()) {
+            // laurent
             switch (event.type) {
                 case 'mouse_down_event':
                     break;
-                    case 'mouse_down_on_existing_point_event':
+                case 'mouse_down_on_existing_point_event':
                     console.info(event.pointIds)
                     console.info('clic existing point')
+                    break;
+                case 'mouse_move_on_label_area_event':
+                    console.info('move !')
+                    
                     break;
                 default:
                     break;

--- a/src/annotation-engine/use-annotation-engine.ts
+++ b/src/annotation-engine/use-annotation-engine.ts
@@ -15,7 +15,16 @@ export interface Handles {
 }
 
 export type PointId = number;
-export type Events = MouseDownEvent | MouseDownOnExistingPointEvent | MouseMove | MouseUp | MouseUpOnExistingPointEvent | MouseWheelEvent;
+export type Events =
+    | MouseDownEvent
+    | MouseDownOnExistingPointEvent
+    | MouseMoveOnExistingPointEvent
+    | MouseMove
+    | MouseUp
+    | ReleaseKeyEvent
+    | PushKeyEvent
+    | MouseUpOnExistingPointEvent
+    | MouseWheelEvent;
 export type OnEvent = (event: Events, operations: Operations) => void;
 
 export interface MouseDownEvent {
@@ -55,15 +64,37 @@ export interface MouseUpOnExistingPointEvent {
     event: MouseEvent;
 }
 
+export interface MouseMoveOnExistingPointEvent {
+    type: 'mouse_move_on_existing_point_event';
+    at: Coordinates;
+    pointIds: Array<PointId>;
+    currentGeometry: Array<Coordinates>;
+    event: MouseEvent;
+}
+
 export interface MouseWheelEvent {
     type: 'mouse_wheel_event';
     deltaX: number;
     deltaY: number;
-    event: WheelEvent
+    event: WheelEvent;
+}
+
+export interface ReleaseKeyEvent {
+    type: 'release_key_event';
+    currentGeometry: Array<Coordinates>;
+    event: KeyboardEvent;
+}
+
+export interface PushKeyEvent {
+    type: 'push_key_event';
+    currentGeometry: Array<Coordinates>;
+    event: KeyboardEvent;
 }
 
 export interface Operations {
     addPoint(at: Coordinates): PointId;
+    highlightExistingPoint(at: Coordinates): void;
+    removeHighlightPoint(): void;
     movePoint(pointId: PointId, to: Coordinates): void;
     finishCurrentLine(): void;
     drawOnCanvas(draw: (context2d: CanvasRenderingContext2D) => void): void;
@@ -78,6 +109,8 @@ const useAnnotationEngine = ({
 }: UseAnnotationEngineArgs): void => {
     const renderingContextRef = useRef<CanvasRenderingContext2D | undefined>(undefined);
     const annotationPointsRef = useRef<Coordinates[]>([]);
+    const annotationHighlightPointIndexRef = useRef<number>(-1);
+    const MOVE_ON_EXISTING_POINTS_RADIUS_DETECTION = 4;
 
     const canvasCoordinateOf = (canvas: HTMLCanvasElement, event: MouseEvent): Coordinates => {
         const rect = canvas.getBoundingClientRect();
@@ -87,11 +120,24 @@ const useAnnotationEngine = ({
             y: event.clientY - rect.top,
         };
     };
-    
-    const detectClickOnExistingPoints = (coordinates: Array<Coordinates>, clickAt: Coordinates): Array<PointId> => coordinates
-            .map((coordinate, idx) => ({coordinate, idx}))
-            .filter(({coordinate}) => areCoordinatesInsideCircle(coordinate, clickAt, 7))
-            .map(({idx}) => idx)
+
+    const detectClickOnExistingPoints = (coordinates: Array<Coordinates>, clickAt: Coordinates): Array<PointId> =>
+        coordinates
+            .map((coordinate, idx) => ({ coordinate, idx }))
+            .filter(({ coordinate }) => areCoordinatesInsideCircle(coordinate, clickAt, 7))
+            .map(({ idx }) => idx);
+
+    const detectMoveOnExistingPoints = (coordinates: Array<Coordinates>, moveOn: Coordinates): Array<PointId> => {
+        const coords = [...coordinates];
+        coords.pop();
+
+        return coords
+            .map((coordinate, idx) => ({ coordinate, idx }))
+            .filter(({ coordinate }) =>
+                areCoordinatesInsideCircle(coordinate, moveOn, MOVE_ON_EXISTING_POINTS_RADIUS_DETECTION),
+            )
+            .map(({ idx }) => idx);
+    };
 
     useEffect(() => {
         if (annotationToEdit) {
@@ -129,7 +175,14 @@ const useAnnotationEngine = ({
 
         drawAnnotations(renderingContextRef.current, annotationsToDraw);
 
-        drawCurrentAnnotation(renderingContextRef.current, annotationPointsRef.current, annotationPointsRef.current === annotationToEdit?.coordinates);
+        // FIXME: ici on dessine les points de annotationPointsRef.current
+        drawCurrentAnnotation(
+            renderingContextRef.current,
+            annotationPointsRef.current,
+            annotationHighlightPointIndexRef.current,
+            annotationPointsRef.current === annotationToEdit?.coordinates,
+            annotationToEdit,
+        );
     }, [annotationsToDraw, canvasRef, annotationToEdit]);
 
     useImperativeHandle(ref, () => ({
@@ -138,7 +191,7 @@ const useAnnotationEngine = ({
                 annotationPointsRef.current = [];
                 drawScene();
             }
-        }
+        },
     }));
 
     // Initialize canvas
@@ -148,7 +201,20 @@ const useAnnotationEngine = ({
         let delayDraw: Array<(context2d: CanvasRenderingContext2D) => void> = [];
         const operations: Operations = {
             addPoint: (at: Coordinates) => annotationPointsRef.current.push(at) - 1,
+            highlightExistingPoint: (at: Coordinates) => {
+                const index = annotationPointsRef.current.findIndex((point) =>
+                    areCoordinatesInsideCircle(point, at, MOVE_ON_EXISTING_POINTS_RADIUS_DETECTION),
+                );
+                if (index === -1) {
+                    return;
+                }
+                annotationHighlightPointIndexRef.current = index;
+            },
+            removeHighlightPoint: () => {
+                annotationHighlightPointIndexRef.current = -1;
+            },
             movePoint: (pointId: PointId, to: Coordinates) => {
+                // FIXME: juste le curseur pendant que ça bouge...
                 annotationPointsRef.current[pointId] = to;
             },
             finishCurrentLine: () => {
@@ -156,7 +222,7 @@ const useAnnotationEngine = ({
             },
             drawOnCanvas: (draw: (context2d: CanvasRenderingContext2D) => void) => {
                 delayDraw.push(draw);
-            }
+            },
         };
 
         const handleEvent = (handler: (canvas: HTMLCanvasElement) => void) => {
@@ -165,73 +231,141 @@ const useAnnotationEngine = ({
                 drawScene();
                 const context2d = currentCanvasRef.getContext('2d');
                 if (context2d) {
-                    delayDraw.forEach(draw => draw(context2d));
+                    delayDraw.forEach((draw) => draw(context2d));
                 }
                 delayDraw = [];
             }
         };
-        
-        const handleMouseUp = (event: MouseEvent) => handleEvent((canvas) => {
-            const eventCoords = canvasCoordinateOf(canvas, event);
-            const isClickOnExistingPointsIdx = detectClickOnExistingPoints(annotationPointsRef.current, eventCoords);
-            
-            if (isClickOnExistingPointsIdx.length > 0) {
-                onEvent({
-                    type: 'mouse_up_on_existing_point_event',
-                    at: eventCoords,
-                    pointIds: isClickOnExistingPointsIdx,
-                    currentGeometry: [...annotationPointsRef.current],
-                    event,
-                }, operations);
-            } else {
-                onEvent({
-                    type: 'mouse_up_event',
-                    at: eventCoords,
-                    currentGeometry: [...annotationPointsRef.current],
-                    event,
-                }, operations);
-            }
-        });
 
-        const handleMouseDown = (event: MouseEvent) => handleEvent((canvas) => {
-            const eventCoords = canvasCoordinateOf(canvas, event);
-            const isClickOnExistingPointsIdx = detectClickOnExistingPoints(annotationPointsRef.current, eventCoords);
-            
-            if (isClickOnExistingPointsIdx.length > 0) {
-                onEvent({
-                    type: 'mouse_down_on_existing_point_event',
-                    at: eventCoords,
-                    pointIds: isClickOnExistingPointsIdx,
-                    currentGeometry: [...annotationPointsRef.current],
-                    event,
-                }, operations);
-            } else {
-                onEvent({
-                    type: 'mouse_down_event',
-                    at: eventCoords,
-                    currentGeometry: [...annotationPointsRef.current],
-                    event,
-                }, operations);
-            }
-        });
+        const handleMouseUp = (event: MouseEvent) =>
+            handleEvent((canvas) => {
+                const eventCoords = canvasCoordinateOf(canvas, event);
+                const isClickOnExistingPointsIdx = detectClickOnExistingPoints(
+                    annotationPointsRef.current,
+                    eventCoords,
+                );
 
-        const handleMouseMove = (event: MouseEvent) => handleEvent((canvas) => {
-            onEvent({
-                type: 'mouse_move_event',
-                to: canvasCoordinateOf(canvas, event),
-                currentGeometry: [...annotationPointsRef.current],
-                event,
-            }, operations);
-        });
+                if (isClickOnExistingPointsIdx.length > 0) {
+                    onEvent(
+                        {
+                            type: 'mouse_up_on_existing_point_event',
+                            at: eventCoords,
+                            pointIds: isClickOnExistingPointsIdx,
+                            currentGeometry: [...annotationPointsRef.current],
+                            event,
+                        },
+                        operations,
+                    );
+                } else {
+                    onEvent(
+                        {
+                            type: 'mouse_up_event',
+                            at: eventCoords,
+                            currentGeometry: [...annotationPointsRef.current],
+                            event,
+                        },
+                        operations,
+                    );
+                }
+            });
 
-        const handleMouseWheel = (event: WheelEvent) => handleEvent(() => {
-            onEvent({
-                type: 'mouse_wheel_event',
-                deltaX: event.deltaX,
-                deltaY: event.deltaY,
-                event,
-            }, operations);
-        });
+        const handleMouseDown = (event: MouseEvent) =>
+            handleEvent((canvas) => {
+                const eventCoords = canvasCoordinateOf(canvas, event);
+                const isClickOnExistingPointsIdx = detectClickOnExistingPoints(
+                    annotationPointsRef.current,
+                    eventCoords,
+                );
+
+                if (isClickOnExistingPointsIdx.length > 0) {
+                    onEvent(
+                        {
+                            type: 'mouse_down_on_existing_point_event',
+                            at: eventCoords,
+                            pointIds: isClickOnExistingPointsIdx,
+                            currentGeometry: [...annotationPointsRef.current],
+                            event,
+                        },
+                        operations,
+                    );
+                } else {
+                    onEvent(
+                        {
+                            type: 'mouse_down_event',
+                            at: eventCoords,
+                            currentGeometry: [...annotationPointsRef.current],
+                            event,
+                        },
+                        operations,
+                    );
+                }
+            });
+
+        const handleMouseMove = (event: MouseEvent) =>
+            handleEvent((canvas) => {
+                const eventCoords = canvasCoordinateOf(canvas, event);
+                const isMoveOnExistingPointsIdx = detectMoveOnExistingPoints(annotationPointsRef.current, eventCoords);
+
+                if (isMoveOnExistingPointsIdx.length > 0) {
+                    onEvent(
+                        {
+                            type: 'mouse_move_on_existing_point_event',
+                            at: eventCoords,
+                            pointIds: isMoveOnExistingPointsIdx,
+                            currentGeometry: [...annotationPointsRef.current],
+                            event,
+                        },
+                        operations,
+                    );
+                } else {
+                    onEvent(
+                        {
+                            type: 'mouse_move_event',
+                            to: canvasCoordinateOf(canvas, event),
+                            currentGeometry: [...annotationPointsRef.current],
+                            event,
+                        },
+                        operations,
+                    );
+                }
+            });
+
+        const handleMouseWheel = (event: WheelEvent) =>
+            handleEvent(() => {
+                onEvent(
+                    {
+                        type: 'mouse_wheel_event',
+                        deltaX: event.deltaX,
+                        deltaY: event.deltaY,
+                        event,
+                    },
+                    operations,
+                );
+            });
+
+        const handleReleaseKey = (event: KeyboardEvent) =>
+            handleEvent(() => {
+                onEvent(
+                    {
+                        type: 'release_key_event',
+                        currentGeometry: [...annotationPointsRef.current],
+                        event,
+                    },
+                    operations,
+                );
+            });
+
+        const handlePushKey = (event: KeyboardEvent) =>
+            handleEvent(() => {
+                onEvent(
+                    {
+                        type: 'push_key_event',
+                        currentGeometry: [...annotationPointsRef.current],
+                        event,
+                    },
+                    operations,
+                );
+            });
 
         if (currentCanvasRef) {
             const canvasRenderingContext = currentCanvasRef.getContext('2d');
@@ -241,6 +375,9 @@ const useAnnotationEngine = ({
                 currentCanvasRef.addEventListener('mouseup', handleMouseUp);
                 currentCanvasRef.addEventListener('mousemove', handleMouseMove);
                 currentCanvasRef.addEventListener('wheel', handleMouseWheel);
+                // FIXME: can not catch key events on canvas :(
+                document.addEventListener('keyup', handleReleaseKey);
+                document.addEventListener('keydown', handlePushKey);
 
                 currentCanvasRef.width = currentCanvasRef.offsetWidth;
                 currentCanvasRef.height = currentCanvasRef.offsetHeight;
@@ -257,6 +394,9 @@ const useAnnotationEngine = ({
                 currentCanvasRef.removeEventListener('mousedown', handleMouseDown);
                 currentCanvasRef.removeEventListener('mousemove', handleMouseMove);
                 currentCanvasRef.removeEventListener('wheel', handleMouseWheel);
+                // FIXME: can not catch key events on canvas :(
+                document.removeEventListener('keyup', handleReleaseKey);
+                document.removeEventListener('keydown', handlePushKey);
             }
         };
     }, [drawScene, canvasRef, onEvent]);

--- a/src/annotation-engine/use-annotation-engine.ts
+++ b/src/annotation-engine/use-annotation-engine.ts
@@ -275,7 +275,18 @@ const useAnnotationEngine = ({
                 const isClickOnExistingPointsIdx = detectClickOnExistingPoints(
                     annotationPointsRef.current,
                     eventCoords,
-                );
+                    );
+                const clickedAnnotation = annotations.find((annotation) => {
+                    const isClickOnPreviouslyDrawnPointsIdx = detectClickOnExistingPoints(
+                        annotation.coordinates,
+                        eventCoords,
+                        )
+
+                    return isClickOnPreviouslyDrawnPointsIdx.length > 0
+                })
+                    console.info('annotations : ', annotations);
+                    console.info('annotPointsRef : ', annotationPointsRef.current);
+                    console.info('clickedAnnotation : ', clickedAnnotation);
 
                 if (isClickOnExistingPointsIdx.length > 0) {
                     onEvent(
@@ -399,7 +410,7 @@ const useAnnotationEngine = ({
                 document.removeEventListener('keydown', handlePushKey);
             }
         };
-    }, [drawScene, canvasRef, onEvent]);
+    }, [drawScene, canvasRef, onEvent, annotations]);
 };
 
 export default useAnnotationEngine;

--- a/src/annotation-engine/use-annotation-engine.ts
+++ b/src/annotation-engine/use-annotation-engine.ts
@@ -344,9 +344,19 @@ const useAnnotationEngine = ({
 
                     return isClickOnPreviouslyDrawnPointsIdx.length > 0
                 })
-                    console.info('annotations : ', annotations);
-                    console.info('annotPointsRef : ', annotationPointsRef.current);
-                    console.info('clickedAnnotation : ', clickedAnnotation);
+
+                const labels = annotations.map((annotation) => annotation?.label);
+                const labelPaths = annotations.map((annotation) => annotation?.label.path);
+                const renderingContext = renderingContextRef.current;
+                labels.forEach((label) => {
+                    if(renderingContext?.isPointInPath(label.path, eventCoords.x, eventCoords.y)) {
+                        console.info(`in label ${label.name} at x : ${eventCoords.x} y : ${eventCoords.y}`)
+                    } else {
+                        
+                        console.info(`not in a label at x : ${eventCoords.x} y : ${eventCoords.y}`)
+                    }
+                });
+                
 
                 if (isClickOnExistingPointsIdx.length > 0) {
                     onEvent(
@@ -377,41 +387,21 @@ const useAnnotationEngine = ({
                 const eventCoords = canvasCoordinateOf(canvas, event);
                 const isMoveOnExistingPointsIdx = detectMoveOnExistingPoints(annotationPointsRef.current, eventCoords);
 
-                // startLaurent
-                const hoverableAreas = annotations.filter((annotation) => annotation.coordinates.length >= 2);
-                // @laurent found on SOF +D
-                const isInsidePolygon = (point: Coordinates, polygonPoints: Coordinates[]) => {
-
-                    const {x} = point; 
-                    const {y} = point;                     
-                    let isInside = false;
-                    for (let i = 0, j = polygonPoints.length - 1; i < polygonPoints.length; j = i++) {
-                        const xi = polygonPoints[i].x;
-                        const yi = polygonPoints[i].y;
-                        const xj = polygonPoints[j].x;
-                        const yj = polygonPoints[j].y;
-                        
-                        const intersect = ((yi > y) !== (yj > y))
-                            && (x < (xj - xi) * (y - yi) / (yj - yi) + xi);
-                        if (intersect) isInside = !isInside;
-                    }
-                    
-                    return isInside;
-                }
-
-                const isInsideExistingPolygon = hoverableAreas.some((hoverableArea) => isInsidePolygon(eventCoords, hoverableArea.coordinates))
-                if (isInsideExistingPolygon) {
-                    onEvent(
-                        {
-                            type: 'mouse_move_on_label_area_event',
-                            at: eventCoords,
-                            pointIds: isMoveOnExistingPointsIdx,
-                            currentGeometry: [...annotationPointsRef.current],
-                            event,
-                        },
-                        operations,
-                    );
-                }
+               
+                // if (isInLabel) {
+                //     onEvent(
+                //         {
+                //             type: 'mouse_move_on_label_area_event',
+                //             at: eventCoords,
+                //             pointIds: isMoveOnExistingPointsIdx,
+                //             currentGeometry: [...annotationPointsRef.current],
+                //             event,
+                //         },
+                //         operations,
+                //     );
+                // } else {
+                //     console.info('no')
+                // }
 
                 // endLaurent
                 if (isMoveOnExistingPointsIdx.length > 0) {

--- a/src/annotation-engine/utils.ts
+++ b/src/annotation-engine/utils.ts
@@ -128,7 +128,7 @@ const drawLabel = (renderingContext: CanvasRenderingContext2D, label: string, fr
     renderingContext.textAlign = 'left';
     renderingContext.translate(from.x, from.y);
     renderingContext.rotate(Math.atan2(distanceY, distanceX));
-    renderingContext.fillStyle = '#FFFFFF';
+    renderingContext.fillStyle = '#F0F';
     drawRoundRect(renderingContext, { x: -2, y: -20 }, textSize.width + 10, 20, 10);
     renderingContext.fillStyle = '#0053CC';
     renderingContext.fillText(label, 2, -5);

--- a/src/annotation-engine/utils.ts
+++ b/src/annotation-engine/utils.ts
@@ -2,6 +2,80 @@
 
 import { Coordinates, Annotation } from './models';
 
+class CanvasBuilder {
+    protected readonly renderingContext: CanvasRenderingContext2D;
+
+    constructor(renderingContext: CanvasRenderingContext2D) {
+        this.renderingContext = renderingContext;
+    }
+
+    beginpath(): CanvasBuilder {
+        this.renderingContext.beginPath();
+
+        return this;
+    }
+
+    closePath(): CanvasBuilder {
+        this.renderingContext.closePath();
+
+        return this;
+    }
+
+    fill(): CanvasBuilder {
+        this.renderingContext.fill();
+
+        return this;
+    }
+
+    fillStyle(hexa: string): CanvasBuilder {
+        this.renderingContext.fillStyle = hexa;
+
+        return this;
+    }
+
+    stroke(): CanvasBuilder {
+        this.renderingContext.stroke();
+
+        return this;
+    }
+
+    strokeStyle(hexa: string): CanvasBuilder {
+        this.renderingContext.strokeStyle = hexa;
+
+        return this;
+    }
+
+    lineWidth(width: number): CanvasBuilder {
+        this.renderingContext.lineWidth = width;
+
+        return this;
+    }
+
+    arc({ x, y }: Coordinates, radius: number): CanvasBuilder {
+        this.renderingContext.arc(x, y, radius, 0, Math.PI * 2, true);
+
+        return this;
+    }
+
+    moveTo({ x, y }: Coordinates): CanvasBuilder {
+        this.renderingContext.moveTo(x, y);
+
+        return this;
+    }
+
+    lineTo({ x, y }: Coordinates): CanvasBuilder {
+        this.renderingContext.lineTo(x, y);
+
+        return this;
+    }
+
+    lineCap(cap: CanvasLineCap): CanvasBuilder {
+        this.renderingContext.lineCap = cap;
+
+        return this;
+    }
+}
+
 export const areCoordinatesInsideCircle = (
     pointCoordinates: Coordinates,
     circleCenterCoordinates: Coordinates,
@@ -61,67 +135,83 @@ const drawLabel = (renderingContext: CanvasRenderingContext2D, label: string, fr
     renderingContext.restore();
 };
 
-export const drawSelectedPoint = (renderingContext: CanvasRenderingContext2D, coordinates: Coordinates): void => {
-    renderingContext.beginPath();
-    renderingContext.strokeStyle = '#0053CC';
-    renderingContext.lineWidth = 2;
-    renderingContext.arc(coordinates.x, coordinates.y, 7, 0, Math.PI * 2, true);
-    renderingContext.stroke();
-    renderingContext.strokeStyle = '#000';
-    renderingContext.closePath();
+export const drawPoint = (
+    type: 'SELECTED' | 'UNSELECTED' | 'HIGHLIGHTED',
+    renderingContext: CanvasRenderingContext2D,
+    coordinates: Coordinates,
+): void => {
+    const cb = new CanvasBuilder(renderingContext);
 
-    renderingContext.beginPath();
-    renderingContext.fillStyle = '#FFFFFF30';
-    renderingContext.arc(coordinates.x, coordinates.y, 5, 0, Math.PI * 2, true);
-    renderingContext.fill();
-    renderingContext.fillStyle = '#000';
-    renderingContext.closePath();
+    cb.beginpath();
+
+    // stroke and line
+    if (type === 'SELECTED') {
+        cb.strokeStyle('#FFF').lineWidth(1);
+    } else if (type === 'HIGHLIGHTED' || type === 'UNSELECTED') {
+        cb.strokeStyle('#FFFFFF95').lineWidth(2);
+    }
+
+    // arc
+    if (type === 'UNSELECTED') {
+        cb.arc(coordinates, 7);
+    } else if (type === 'SELECTED') {
+        cb.arc(coordinates, 8);
+    } else if (type === 'HIGHLIGHTED') {
+        cb.arc(coordinates, 14);
+    }
+
+    cb.stroke();
+
+    if (type === 'SELECTED' || type === 'UNSELECTED') {
+        cb.strokeStyle('#000');
+    }
+
+    cb.closePath();
+
+    cb.beginpath();
+
+    // fill
+    if (type === 'SELECTED' || type === 'HIGHLIGHTED') {
+        cb.fillStyle('#0053CC66');
+    } else if (type === 'UNSELECTED') {
+        cb.fillStyle('#0053CC30');
+    }
+
+    // arc
+    if (type === 'SELECTED') {
+        cb.arc(coordinates, 8);
+    } else if (type === 'UNSELECTED') {
+        cb.arc(coordinates, 5);
+    } else if (type === 'HIGHLIGHTED') {
+        cb.arc(coordinates, 12);
+    }
+
+    cb.fill();
+
+    if (type === 'SELECTED' || type === 'UNSELECTED') {
+        cb.strokeStyle('#000');
+    }
+
+    cb.closePath();
 };
 
-export const drawUnselectedPoint = (renderingContext: CanvasRenderingContext2D, coordinates: Coordinates): void => {
-    renderingContext.beginPath();
-    renderingContext.strokeStyle = '#FFFFFF95';
-    renderingContext.lineWidth = 2;
-    renderingContext.arc(coordinates.x, coordinates.y, 7, 0, Math.PI * 2, true);
-    renderingContext.stroke();
-    renderingContext.strokeStyle = '#000';
-    renderingContext.closePath();
-
-    renderingContext.beginPath();
-    renderingContext.fillStyle = '#0053CC30';
-    renderingContext.arc(coordinates.x, coordinates.y, 5, 0, Math.PI * 2, true);
-    renderingContext.fill();
-    renderingContext.fillStyle = '#000';
-    renderingContext.closePath();
-};
-
-export const drawSelectedLine = (
+export const drawLine = (
+    type: 'SELECTED' | 'UNSELECTED',
     renderingContext: CanvasRenderingContext2D,
     startCoordinates: Coordinates,
     endCoordinates: Coordinates,
 ): void => {
-    renderingContext.beginPath();
-    renderingContext.strokeStyle = '#0053CC';
-    renderingContext.moveTo(startCoordinates.x, startCoordinates.y);
-    renderingContext.lineWidth = 2;
-    renderingContext.lineTo(endCoordinates.x, endCoordinates.y);
-    renderingContext.stroke();
-    renderingContext.closePath();
-};
+    const cb = new CanvasBuilder(renderingContext);
 
-export const drawUnselectedLine = (
-    renderingContext: CanvasRenderingContext2D,
-    startCoordinates: Coordinates,
-    endCoordinates: Coordinates,
-): void => {
-    renderingContext.beginPath();
-    renderingContext.strokeStyle = '#FFFFFF';
-    renderingContext.lineCap = 'round';
-    renderingContext.moveTo(startCoordinates.x, startCoordinates.y);
-    renderingContext.lineTo(endCoordinates.x, endCoordinates.y);
-    renderingContext.lineWidth = 2;
-    renderingContext.stroke();
-    renderingContext.closePath();
+    cb.beginpath();
+
+    if (type === 'SELECTED') {
+        cb.strokeStyle('#0053CC');
+    } else if (type === 'UNSELECTED') {
+        cb.strokeStyle('#FFFFFF').lineCap('round');
+    }
+
+    cb.moveTo(startCoordinates).lineTo(endCoordinates).lineWidth(2).stroke().closePath();
 };
 
 export const drawAnnotations = (renderingContext: CanvasRenderingContext2D, annotations: Annotation[]): void => {
@@ -129,9 +219,15 @@ export const drawAnnotations = (renderingContext: CanvasRenderingContext2D, anno
         let previousCoordinates: Coordinates | undefined =
             annotation.coordinates.length > 2 ? annotation.coordinates[annotation.coordinates.length - 1] : undefined;
 
-        annotation.coordinates.forEach((coordinates: Coordinates) => {
+        annotation.coordinates.forEach((coordinates: Coordinates, index: number) => {
             if (previousCoordinates) {
-                drawUnselectedLine(renderingContext, previousCoordinates, coordinates);
+                if (annotation.type === 'POLYLINE') {
+                    if (index > 0) {
+                        drawLine('UNSELECTED', renderingContext, previousCoordinates, coordinates);
+                    }
+                } else {
+                    drawLine('UNSELECTED', renderingContext, previousCoordinates, coordinates);
+                }
             }
 
             previousCoordinates = coordinates;
@@ -148,7 +244,7 @@ export const drawAnnotations = (renderingContext: CanvasRenderingContext2D, anno
                 x: middlePoint.x + textSize.width / 2,
                 y: middlePoint.y - 10,
             };
-            drawUnselectedPoint(renderingContext, middlePoint);
+            drawPoint('UNSELECTED', renderingContext, middlePoint);
             drawLabel(renderingContext, annotation.name, firstPoint, secondPoint);
         }
         if (annotation.coordinates.length >= 2) {
@@ -162,19 +258,27 @@ export const drawAnnotations = (renderingContext: CanvasRenderingContext2D, anno
 export const drawCurrentAnnotation = (
     renderingContext: CanvasRenderingContext2D,
     annotationPoints: Coordinates[],
+    annotationHighlightPointIndex: number,
     isComplete: boolean,
+    currentAnnotation?: Annotation,
 ): void => {
-    annotationPoints.forEach((annotationPoint: Coordinates) => {
-        drawSelectedPoint(renderingContext, annotationPoint);
+    annotationPoints.forEach((annotationPoint: Coordinates, index: number) => {
+        if (index === annotationHighlightPointIndex) {
+            drawPoint('HIGHLIGHTED', renderingContext, annotationPoint);
+        } else {
+            drawPoint('SELECTED', renderingContext, annotationPoint);
+        }
     });
 
     if (annotationPoints.length > 1) {
         for (let i = 1; i < annotationPoints.length; i++) {
-            drawSelectedLine(renderingContext, annotationPoints[i - 1], annotationPoints[i]);
+            drawLine('SELECTED', renderingContext, annotationPoints[i - 1], annotationPoints[i]);
         }
     }
 
     if (isComplete) {
-        drawSelectedLine(renderingContext, annotationPoints[annotationPoints.length - 1], annotationPoints[0]);
+        if (currentAnnotation?.type !== 'POLYLINE') {
+            drawLine('SELECTED', renderingContext, annotationPoints[annotationPoints.length - 1], annotationPoints[0]);
+        }
     }
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9805,10 +9805,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.2.tgz#399ab18aac45802d6f2498de5054fcbbe716a805"
-  integrity sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==
+typescript@4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.2.tgz#1450f020618f872db0ea17317d16d8da8ddb8c4c"
+  integrity sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Là où j'en suis :
- créé un nouvel event quand on survole un élément du canvas
- réaction au survol des polygones déjà tracés (merci stackoverflow pour l'algo permettant de savoir si on est dans un polygone ou pas ^^)
- des commentaires partout pour prendre mes repères :scream: 

Hypothèses pour la suite :
- si on veut cliquer sur la forme (et pas sur le label) : pour chaque annotation, générer une "hoverableShape" qui correspondrait au tracé de la forme, avec un empâtement (un rectangle fin pour une ligne, un disque pour un point, un polygone à large bords...). Un event se déclenche en survolant / cliquant cette forme.
- si on veut cliquer sur le label : pas simple, car le label est tracé dans le canvas, mais ses coordonnées ne sont pas mémorisées. Solution possible : avoir une fonction du type "getLabelHoverableShape" qui prend en paramètre une annotation, et en reconstruit les coordonnées de son label => prévoir une mutualisation de la logique entre cette future fonction et la fonction drawLabel. Même mécanique, lorsque la souris survole / clique l'une de ces labelHoverableShapes, bim !
- créer un état supplémentaire "HOVERED" pour afficher différemment les éléments survolés (ou dont le label est survolé)